### PR TITLE
Work around RGBXYZ stream hangs (issue #25)

### DIFF
--- a/camera/src/realsense_camera_nodelet.cpp
+++ b/camera/src/realsense_camera_nodelet.cpp
@@ -926,11 +926,12 @@ namespace realsense_camera
     checkError();
 
     ros::Duration sleeper(0.1); // 100ms
+    ros::Duration sleeper_with_eps(0.12);
 
     while (ros::ok())
     {
       // time stamp is future dated to be valid for given duration
-      ros::Time time_stamp = ros::Time::now() + sleeper;
+      ros::Time time_stamp = ros::Time::now() + sleeper_with_eps;
 
       // transform base frame to depth frame
       tr.setOrigin(tf::Vector3(z_extrinsic.translation[0], z_extrinsic.translation[1], z_extrinsic.translation[2]));


### PR DESCRIPTION
Fixes Issue: #25

Changes proposed in this pull request:
- Shift TF timestamps into the future to work around synchronization issues with the rgbd_launch pipeline


Apparently, this is triggered when the depth_image_proc/register nodelet
fails with a TF2 'timestamp is in the future' error and doesn't publish
the registered depth image properly. This seems to cause the ROS
Synchronizer filter to choke.

Work around by moving the published timestamp further into the future.